### PR TITLE
added text bookmarks

### DIFF
--- a/bookmarks.h
+++ b/bookmarks.h
@@ -1,0 +1,71 @@
+#pragma once
+#include <array>
+#include <string>
+#include "editor.h"
+#include "files.h"
+#include "imgui.h"
+
+class Bookmarks {
+private:
+    struct Bookmark {
+        std::string filePath;
+        int cursorPosition;
+        int lineNumber;
+        bool isSet;
+
+        Bookmark() : filePath(""), cursorPosition(0), lineNumber(0), isSet(false) {}
+    };
+
+    static constexpr size_t NUM_BOOKMARKS = 9;
+    std::array<Bookmark, NUM_BOOKMARKS> bookmarks;
+
+public:
+    inline void setBookmark(size_t slot, const std::string& filePath, int cursorPosition, int lineNumber) {
+        if (slot < NUM_BOOKMARKS) {
+            bookmarks[slot].filePath = filePath;
+            bookmarks[slot].cursorPosition = cursorPosition;
+            bookmarks[slot].lineNumber = lineNumber;
+            bookmarks[slot].isSet = true;
+        }
+    }
+
+    inline bool jumpToBookmark(size_t slot, FileExplorer& fileExplorer, EditorState& editorState) {
+        if (slot < NUM_BOOKMARKS && bookmarks[slot].isSet) {
+            if (bookmarks[slot].filePath != fileExplorer.getCurrentFile()) {
+                fileExplorer.saveCurrentFile();
+                fileExplorer.loadFileContent(bookmarks[slot].filePath);
+            }
+            editorState.cursor_pos = bookmarks[slot].cursorPosition;
+            editorState.current_line = bookmarks[slot].lineNumber;
+            return true;
+        }
+        return false;
+    }
+
+    inline void handleBookmarkInput(FileExplorer& fileExplorer, EditorState& editorState) {
+        bool ctrl_pressed = ImGui::GetIO().KeyCtrl;
+        bool shift_pressed = ImGui::GetIO().KeyShift;
+
+        const ImGuiKey numberKeys[9] = {
+            ImGuiKey_1, ImGuiKey_2, ImGuiKey_3, ImGuiKey_4, ImGuiKey_5,
+            ImGuiKey_6, ImGuiKey_7, ImGuiKey_8, ImGuiKey_9
+        };
+
+        for (int i = 0; i < NUM_BOOKMARKS; ++i) {
+            if (ctrl_pressed && ImGui::IsKeyPressed(numberKeys[i])) {
+                if (shift_pressed) {
+                    setBookmark(i, fileExplorer.getCurrentFile(), editorState.cursor_pos, editorState.current_line);
+                    std::cout << "Bookmark " << (i + 1) << " set at line " << editorState.current_line << std::endl;
+                } else {
+                    if (jumpToBookmark(i, fileExplorer, editorState)) {
+                        std::cout << "Jumped to bookmark " << (i + 1) << std::endl;
+                    } else {
+                        std::cout << "Bookmark " << (i + 1) << " not set" << std::endl;
+                    }
+                }
+            }
+        }
+    }
+};
+
+extern Bookmarks gBookmarks;

--- a/editor.h
+++ b/editor.h
@@ -1,94 +1,94 @@
-#pragma once
-#include <string>
-#include <vector>
-#include <regex>
-#include <unordered_map>
-#include "imgui.h"
-#include <future>
-#include <atomic>
-#include <mutex>
-//
+        #pragma once
+        #include <string>
+        #include <vector>
+        #include <regex>
+        #include <unordered_map>
+        #include "imgui.h"
+        #include <future>
+        #include <atomic>
+        #include <mutex>
+        //
 
-struct SyntaxRule {
-    std::regex pattern;
-    ImVec4 color;
-};
-struct EditorState {
-    int cursor_pos = 0;
-    int selection_start = 0;
-    int selection_end = 0;
-    bool is_selecting = false; 
-    std::vector<int> line_starts = {0};
-    ImVec2 scroll_pos = ImVec2(0, 0); //vertical scroll
-    float scroll_x = 0.0f;  // Horizontal scroll
-    bool rainbow_cursor = true;
-    float cursor_blink_time = 0.0f;
-    bool activateFindBox = false;
-    bool blockInput = false;
-    int current_line;
-    
-};
-struct ScrollChange {
-    bool vertical;
-    bool horizontal;
-};
-struct CursorVisibility {
-    bool vertical;
-    bool horizontal;
-};
-
-
-
-class Editor {
-public:
-    void setLanguage(const std::string& extension);
-    void highlightContent(const std::string& content, std::vector<ImVec4>& colors, int start_pos, int end_pos);
-    void setTheme(const std::string& themeName);
-    
-    void moveWordForward(const std::string& text, EditorState& state);
-    void moveWordBackward(const std::string& text, EditorState& state);
-    void removeIndentation(std::string& text, EditorState& state);
-
-    
-private:
-    std::vector<SyntaxRule> rules;
-    std::vector<SyntaxRule> htmlRules;
-    std::vector<SyntaxRule> javascriptRules;
-    std::vector<SyntaxRule> cssRules;
-    std::vector<SyntaxRule> cppRules;
-    std::vector<SyntaxRule> pythonRules;
-    std::vector<SyntaxRule> markdownRules;
-    std::vector<SyntaxRule> jsonRules;
-    
-    void setupCppRules();
-    void setupPythonRules();
-    void setupJavaScriptRules();
-    void setupMarkdownRules();  
-    void setupHtmlRules();      
-    void setupCssRules(); 
-    void setupJsonRules();
-    
-    void loadTheme(const std::string& themeName);
-    std::unordered_map<std::string, ImVec4> themeColors;
-    void applyRules(const std::string& view, std::vector<ImVec4>& colors, int start_pos, const std::vector<SyntaxRule>& rules);
-    std::future<void> highlightFuture;
-    std::atomic<bool> highlightingInProgress{false};
-    std::mutex colorsMutex;
-    
-};
-extern EditorState editor_state;
-extern Editor gEditor;
+        struct SyntaxRule {
+            std::regex pattern;
+            ImVec4 color;
+        };
+        struct EditorState {
+            int cursor_pos = 0;
+            int selection_start = 0;
+            int selection_end = 0;
+            bool is_selecting = false; 
+            std::vector<int> line_starts = {0};
+            ImVec2 scroll_pos = ImVec2(0, 0); //vertical scroll
+            float scroll_x = 0.0f;  // Horizontal scroll
+            bool rainbow_cursor = true;
+            float cursor_blink_time = 0.0f;
+            bool activateFindBox = false;
+            bool blockInput = false;
+            int current_line;
+            
+        };
+        struct ScrollChange {
+            bool vertical;
+            bool horizontal;
+        };
+        struct CursorVisibility {
+            bool vertical;
+            bool horizontal;
+        };
 
 
-inline ImVec4 GetRainbowColor(float t) {
-    float r = sin(t) * 0.5f + 0.5f;
-    float g = sin(t + 2.0944f) * 0.5f + 0.5f; // 2.0944 is 2π/3
-    float b = sin(t + 4.1888f) * 0.5f + 0.5f; // 4.1888 is 4π/3
-    return ImVec4(r, g, b, 1.0f);
-}
+
+        class Editor {
+        public:
+            void setLanguage(const std::string& extension);
+            void highlightContent(const std::string& content, std::vector<ImVec4>& colors, int start_pos, int end_pos);
+            void setTheme(const std::string& themeName);
+            
+            void moveWordForward(const std::string& text, EditorState& state);
+            void moveWordBackward(const std::string& text, EditorState& state);
+            void removeIndentation(std::string& text, EditorState& state);
+
+            
+        private:
+            std::vector<SyntaxRule> rules;
+            std::vector<SyntaxRule> htmlRules;
+            std::vector<SyntaxRule> javascriptRules;
+            std::vector<SyntaxRule> cssRules;
+            std::vector<SyntaxRule> cppRules;
+            std::vector<SyntaxRule> pythonRules;
+            std::vector<SyntaxRule> markdownRules;
+            std::vector<SyntaxRule> jsonRules;
+            
+            void setupCppRules();
+            void setupPythonRules();
+            void setupJavaScriptRules();
+            void setupMarkdownRules();  
+            void setupHtmlRules();      
+            void setupCssRules(); 
+            void setupJsonRules();
+            
+            void loadTheme(const std::string& themeName);
+            std::unordered_map<std::string, ImVec4> themeColors;
+            void applyRules(const std::string& view, std::vector<ImVec4>& colors, int start_pos, const std::vector<SyntaxRule>& rules);
+            std::future<void> highlightFuture;
+            std::atomic<bool> highlightingInProgress{false};
+            std::mutex colorsMutex;
+            
+        };
+        extern EditorState editor_state;
+        extern Editor gEditor;
 
 
-void HandleEditorInput(const std::string& text, EditorState& state, const ImVec2& text_start_pos, float line_height, bool& text_changed, std::vector<ImVec4>& colors);
-bool CustomTextEditor(const char* label, std::string& text, std::vector<ImVec4>& colors, EditorState& editor_state);
-ScrollChange EnsureCursorVisible(const ImVec2& text_pos, const std::string& text, EditorState& state, float line_height, float window_height, float window_width);
+        inline ImVec4 GetRainbowColor(float t) {
+            float r = sin(t) * 0.5f + 0.5f;
+            float g = sin(t + 2.0944f) * 0.5f + 0.5f; // 2.0944 is 2π/3
+            float b = sin(t + 4.1888f) * 0.5f + 0.5f; // 4.1888 is 4π/3
+            return ImVec4(r, g, b, 1.0f);
+        }
+
+
+        void HandleEditorInput(const std::string& text, EditorState& state, const ImVec2& text_start_pos, float line_height, bool& text_changed, std::vector<ImVec4>& colors);
+        bool CustomTextEditor(const char* label, std::string& text, std::vector<ImVec4>& colors, EditorState& editor_state);
+        ScrollChange EnsureCursorVisible(const ImVec2& text_pos, const std::string& text, EditorState& state, float line_height, float window_height, float window_width);
 

--- a/files.cpp
+++ b/files.cpp
@@ -310,6 +310,14 @@ void FileExplorer::loadFileContent(const std::string& path) {
             currentOpenFile = path;
         }
         _unsavedChanges = false;
+        
+        // Resize fileColors to match fileContent
+        fileColors.clear();
+        fileColors.resize(fileContent.size(), ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+        if (fileContent.size() != fileColors.size()) {
+            std::cerr << "Error: Mismatch between fileContent and fileColors size after loading" << std::endl;
+            return;
+        }
         auto it = fileUndoManagers.find(path);
         if (it == fileUndoManagers.end()) {
             it = fileUndoManagers.emplace(path, UndoRedoManager()).first;
@@ -318,14 +326,16 @@ void FileExplorer::loadFileContent(const std::string& path) {
             std::cout << "Using existing UndoRedoManager for " << path << std::endl;
         }
         currentUndoManager = &(it->second);
-        //currentUndoManager->addState(fileContent);
 
         std::string extension = fs::path(path).extension().string();
         gEditor.setLanguage(extension);
         
-        fileColors.clear();
-        fileColors.resize(fileContent.size(), ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
-        gEditor.highlightContent(fileContent, fileColors, 0, fileContent.size());
+        // Check if fileContent and fileColors have the same size before highlighting
+        if (fileContent.size() == fileColors.size()) {
+            gEditor.highlightContent(fileContent, fileColors, 0, fileContent.size());
+        } else {
+            std::cerr << "Error: fileContent and fileColors size mismatch" << std::endl;
+        }
 
         std::cout << "Loaded file: " << path << std::endl;
         std::cout << "File size: " << fileContent.size() << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,9 @@
 #include <filesystem>
 #include <unistd.h>
 #include <chrono>
+#include "bookmarks.h"
+Bookmarks gBookmarks;
+
 
 float Clamp(float value, float min, float max) {
     if (value < min) return min;
@@ -172,7 +175,7 @@ int main() {
     GLFWwindow* window = CreateWindow();
     InitializeImGui(window);
 
-    gSettings.loadSettings();
+    gSettings.loadSettings();   
     gEditor.setTheme(gSettings.getCurrentTheme());
 
     bool windowFocused = true;
@@ -267,7 +270,6 @@ int main() {
 
         last_frame_time = frame_start;
     }
-
     gSettings.saveSettings();
     gFileExplorer.saveCurrentFile();
 


### PR DESCRIPTION
added text bookmarks similar to tabs.  we didnt have a tab system so this open up keybinds normally used for tabs like cmd/ctrl 1-9.   Its works by saving a bookmark spot in a file both the line and horizontal character position aswell as the file path.  There are 9 bookmark "slots" 1-9, to set a bookmark use the keybind cmd shift 1, to jump back to the bookmark press cmd 1.   you can jump in the same file from one bookmark to another, or across multiple files.   This is essentially tab like behavior just improved a bit.   in the future it would be nice to have little popup window maybe command b to display the current bookmarks in a list like.... timestamp, filepath, coordinates..... and so on...