### PR TITLE
added cmd b to show bookmarks

### DIFF
--- a/bookmarks.h
+++ b/bookmarks.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <array>
 #include <string>
 #include "editor.h"
@@ -14,18 +15,18 @@ private:
         bool isSet;
 
         Bookmark() : filePath(""), cursorPosition(0), lineNumber(0), isSet(false) {}
+        Bookmark(const std::string& path, int cursor, int line, bool set)
+            : filePath(path), cursorPosition(cursor), lineNumber(line), isSet(set) {}
     };
 
     static constexpr size_t NUM_BOOKMARKS = 9;
     std::array<Bookmark, NUM_BOOKMARKS> bookmarks;
+    bool showBookmarksWindow = false;
 
 public:
     inline void setBookmark(size_t slot, const std::string& filePath, int cursorPosition, int lineNumber) {
         if (slot < NUM_BOOKMARKS) {
-            bookmarks[slot].filePath = filePath;
-            bookmarks[slot].cursorPosition = cursorPosition;
-            bookmarks[slot].lineNumber = lineNumber;
-            bookmarks[slot].isSet = true;
+            bookmarks[slot] = Bookmark(filePath, cursorPosition, lineNumber, true);
         }
     }
 
@@ -41,30 +42,86 @@ public:
         }
         return false;
     }
-
+  
     inline void handleBookmarkInput(FileExplorer& fileExplorer, EditorState& editorState) {
-        bool ctrl_pressed = ImGui::GetIO().KeyCtrl;
+        bool main_key = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
         bool shift_pressed = ImGui::GetIO().KeyShift;
+        bool alt_pressed = ImGui::GetIO().KeyAlt;
 
-        const ImGuiKey numberKeys[9] = {
-            ImGuiKey_1, ImGuiKey_2, ImGuiKey_3, ImGuiKey_4, ImGuiKey_5,
-            ImGuiKey_6, ImGuiKey_7, ImGuiKey_8, ImGuiKey_9
-        };
+        if (main_key && ImGui::IsKeyPressed(ImGuiKey_B, false)) {  // false to not repeat
+            showBookmarksWindow = !showBookmarksWindow;
+            //editorState.blockInput = showBookmarksWindow;  // Block input when window is open
+            return;
+        }
 
-        for (int i = 0; i < NUM_BOOKMARKS; ++i) {
-            if (ctrl_pressed && ImGui::IsKeyPressed(numberKeys[i])) {
-                if (shift_pressed) {
-                    setBookmark(i, fileExplorer.getCurrentFile(), editorState.cursor_pos, editorState.current_line);
-                    std::cout << "Bookmark " << (i + 1) << " set at line " << editorState.current_line << std::endl;
-                } else {
-                    if (jumpToBookmark(i, fileExplorer, editorState)) {
-                        std::cout << "Jumped to bookmark " << (i + 1) << std::endl;
+        if (!showBookmarksWindow) {  // Only handle number keys when bookmarks window is closed
+            const ImGuiKey numberKeys[9] = {
+                ImGuiKey_1, ImGuiKey_2, ImGuiKey_3, ImGuiKey_4, ImGuiKey_5,
+                ImGuiKey_6, ImGuiKey_7, ImGuiKey_8, ImGuiKey_9
+            };
+
+            for (size_t i = 0; i < NUM_BOOKMARKS; ++i) {
+                if (main_key && ImGui::IsKeyPressed(numberKeys[i])) {
+                    if (shift_pressed || alt_pressed) {
+                        setBookmark(i, fileExplorer.getCurrentFile(), editorState.cursor_pos, editorState.current_line);
+                        std::cout << "Bookmark " << (i + 1) << " set at line " << editorState.current_line << std::endl;
                     } else {
-                        std::cout << "Bookmark " << (i + 1) << " not set" << std::endl;
+                        if (jumpToBookmark(i, fileExplorer, editorState)) {
+                            std::cout << "Jumped to bookmark " << (i + 1) << std::endl;
+                        } else {
+                            std::cout << "Bookmark " << (i + 1) << " not set" << std::endl;
+                        }
                     }
                 }
             }
         }
+    }
+    inline void renderBookmarksWindow() {
+        if (showBookmarksWindow) {
+            ImGui::SetNextWindowSize(ImVec2(600, 400));
+            ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x * 0.5f, ImGui::GetIO().DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+            
+            ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | 
+                                           ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | 
+                                           ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;
+
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.0f);
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 5.0f);
+            ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.2f, 0.2f, 0.2f, 1.0f)); // Solid, opaque dark gray background
+            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.7f, 0.7f, 0.7f, 1.0f));
+            
+            ImGui::Begin("Bookmarks", nullptr, windowFlags);
+            
+            ImGui::SetWindowFontScale(1.2f);
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.0f), "Bookmarks");
+            ImGui::Separator();
+
+            ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), false, ImGuiWindowFlags_HorizontalScrollbar);
+            for (size_t i = 0; i < NUM_BOOKMARKS; ++i) {
+                if (bookmarks[i].isSet) {
+                    ImGui::TextColored(ImVec4(0.7f, 0.7f, 1.0f, 1.0f), "%zu:", i + 1);
+                    ImGui::SameLine();
+                    ImGui::TextWrapped("%s (Line %d, Pos %d)", 
+                        bookmarks[i].filePath.c_str(), 
+                        bookmarks[i].lineNumber, bookmarks[i].cursorPosition);
+                } else {
+                    ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), " %zu: Empty slot", i + 1);
+                }
+            }
+            ImGui::EndChild();
+
+            ImGui::Separator();
+            ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "Press Cmd+B to close this window");
+
+            ImGui::End();
+
+            ImGui::PopStyleColor(2);
+            ImGui::PopStyleVar(2);
+        }
+    }
+
+    inline bool isWindowOpen() const {
+        return showBookmarksWindow;
     }
 };
 

--- a/editor.h
+++ b/editor.h
@@ -14,20 +14,25 @@
             ImVec4 color;
         };
         struct EditorState {
-            int cursor_pos = 0;
-            int selection_start = 0;
-            int selection_end = 0;
-            bool is_selecting = false; 
-            std::vector<int> line_starts = {0};
-            ImVec2 scroll_pos = ImVec2(0, 0); //vertical scroll
-            float scroll_x = 0.0f;  // Horizontal scroll
-            bool rainbow_cursor = true;
-            float cursor_blink_time = 0.0f;
-            bool activateFindBox = false;
-            bool blockInput = false;
+            int cursor_pos;
+            int selection_start;
+            int selection_end;
+            bool is_selecting;
+            std::vector<int> line_starts;
+            ImVec2 scroll_pos;
+            float scroll_x;
+            bool rainbow_cursor;
+            float cursor_blink_time;
+            bool activateFindBox;
+            bool blockInput;
             int current_line;
-            
+
+            EditorState()
+                : cursor_pos(0), selection_start(0), selection_end(0), is_selecting(false),
+                line_starts({0}), scroll_pos(0, 0), scroll_x(0.0f), rainbow_cursor(true),
+                cursor_blink_time(0.0f), activateFindBox(false), blockInput(false), current_line(0) {}
         };
+
         struct ScrollChange {
             bool vertical;
             bool horizontal;
@@ -37,45 +42,47 @@
             bool horizontal;
         };
 
+class Editor {
+    public:
+        void setLanguage(const std::string& extension);
+        void highlightContent(const std::string& content, std::vector<ImVec4>& colors, int start_pos, int end_pos);
+        void setTheme(const std::string& themeName);
+        void moveWordForward(const std::string& text, EditorState& state);
+        void moveWordBackward(const std::string& text, EditorState& state);
+        void removeIndentation(std::string& text, EditorState& state);
 
+    private:
+        std::vector<SyntaxRule> rules;
+        std::vector<SyntaxRule> htmlRules;
+        std::vector<SyntaxRule> javascriptRules;
+        std::vector<SyntaxRule> cssRules;
+        std::vector<SyntaxRule> cppRules;
+        std::vector<SyntaxRule> pythonRules;
+        std::vector<SyntaxRule> markdownRules;
+        std::vector<SyntaxRule> jsonRules;
+        std::vector<SyntaxRule> goRules;
+        std::vector<SyntaxRule> javaRules;
+        std::vector<SyntaxRule> csharpRules;
 
-        class Editor {
-        public:
-            void setLanguage(const std::string& extension);
-            void highlightContent(const std::string& content, std::vector<ImVec4>& colors, int start_pos, int end_pos);
-            void setTheme(const std::string& themeName);
-            
-            void moveWordForward(const std::string& text, EditorState& state);
-            void moveWordBackward(const std::string& text, EditorState& state);
-            void removeIndentation(std::string& text, EditorState& state);
+        void setupCppRules();
+        void setupPythonRules();
+        void setupJavaScriptRules();
+        void setupMarkdownRules();
+        void setupHtmlRules();
+        void setupCssRules();
+        void setupJsonRules();
+        void setupGoRules();
+        void setupJavaRules();
+        void setupCSharpRules();
 
-            
-        private:
-            std::vector<SyntaxRule> rules;
-            std::vector<SyntaxRule> htmlRules;
-            std::vector<SyntaxRule> javascriptRules;
-            std::vector<SyntaxRule> cssRules;
-            std::vector<SyntaxRule> cppRules;
-            std::vector<SyntaxRule> pythonRules;
-            std::vector<SyntaxRule> markdownRules;
-            std::vector<SyntaxRule> jsonRules;
-            
-            void setupCppRules();
-            void setupPythonRules();
-            void setupJavaScriptRules();
-            void setupMarkdownRules();  
-            void setupHtmlRules();      
-            void setupCssRules(); 
-            void setupJsonRules();
-            
-            void loadTheme(const std::string& themeName);
-            std::unordered_map<std::string, ImVec4> themeColors;
-            void applyRules(const std::string& view, std::vector<ImVec4>& colors, int start_pos, const std::vector<SyntaxRule>& rules);
-            std::future<void> highlightFuture;
-            std::atomic<bool> highlightingInProgress{false};
-            std::mutex colorsMutex;
-            
-        };
+        void loadTheme(const std::string& themeName);
+        std::unordered_map<std::string, ImVec4> themeColors;
+        void applyRules(const std::string& view, std::vector<ImVec4>& colors, int start_pos, const std::vector<SyntaxRule>& rules);
+        
+        std::future<void> highlightFuture;
+        std::atomic<bool> highlightingInProgress{false};
+        std::mutex colorsMutex;
+    };
         extern EditorState editor_state;
         extern Editor gEditor;
 

--- a/files.cpp
+++ b/files.cpp
@@ -232,7 +232,7 @@ void FileExplorer::displayFileTree(FileNode& node) {
         ImGui::SetCursorPosX(ImGui::GetItemRectMin().x);
         ImGui::Image(icon, ImVec2(icon_width, icon_width));
         ImGui::SameLine(0, icon_spacing);
-        bool useRainbowEffect = false;
+        bool useRainbowEffect = true;
         // Use rainbow color for the active file
         if (node.fullPath == currentOpenFile) {
         ImVec4 fileColor;
@@ -432,14 +432,22 @@ void FileExplorer::renderFileContent() {
     
     if (editor_state.activateFindBox) {
         ImGui::SetNextItemWidth(-1);
+        
+        // Push the new style color for the input text background
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.2f, 0.2f, 0.2f, 1.0f)); // Dark gray background
+        
         static char inputBuffer[256] = "";
         ImGui::SetKeyboardFocusHere();
         ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll;
+        
         if (ImGui::InputText("##findbox", inputBuffer, sizeof(inputBuffer), flags)) {
             findText = inputBuffer;
             lastFoundPos = std::string::npos;  // Reset lastFoundPos for new search
             findNext();
         }
+        
+        // Pop the style color to restore the original color
+        ImGui::PopStyleColor();
         
         bool shift_pressed = ImGui::GetIO().KeyShift;
         if (ImGui::IsKeyPressed(ImGuiKey_Enter, false)) {
@@ -457,8 +465,6 @@ void FileExplorer::renderFileContent() {
             editor_state.blockInput = false;
         }
     }
-
-
 
     // Always render the editor
     bool text_changed = CustomTextEditor("##editor", fileContent, fileColors, editor_state);

--- a/main.cpp
+++ b/main.cpp
@@ -159,6 +159,9 @@ void RenderMainWindow(ImFont* currentFont, float& explorerWidth, float& editorWi
     ImGui::PopStyleColor();
     ImGui::PopStyleVar();
     ImGui::End();
+    gBookmarks.renderBookmarksWindow();
+
+
 }
 void updateFileExplorer() {
     static float last_refresh_time = 0.0f;

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,120 +1,120 @@
-#include "settings.h"
-#include <iostream>
-#include <fstream>
+    #include "settings.h"
+    #include <iostream>
+    #include <fstream>
 
-Settings gSettings;
+    Settings gSettings;
 
-Settings::Settings() : splitPos(0.3f) {}
+    Settings::Settings() : splitPos(0.3f) {}
 
-void Settings::loadSettings() {
-    settingsPath = std::string(getenv("HOME")) + "/.ned.json";
-    std::cout << "Attempting to load settings from: " << settingsPath << std::endl;
-    std::ifstream settingsFile(settingsPath);
-    if (settingsFile.is_open()) {
-        try {
-            settingsFile >> settings;
-            std::cout << "Settings loaded successfully" << std::endl;
-        } catch (json::parse_error& e) {
-            std::cerr << "Error parsing settings file: " << e.what() << std::endl;
-            settings = json::object(); // Reset to empty object
+    void Settings::loadSettings() {
+        settingsPath = std::string(getenv("HOME")) + "/.ned.json";
+        std::cout << "Attempting to load settings from: " << settingsPath << std::endl;
+        std::ifstream settingsFile(settingsPath);
+        if (settingsFile.is_open()) {
+            try {
+                settingsFile >> settings;
+                std::cout << "Settings loaded successfully" << std::endl;
+            } catch (json::parse_error& e) {
+                std::cerr << "Error parsing settings file: " << e.what() << std::endl;
+                settings = json::object(); // Reset to empty object
+            }
+        } else {
+            std::cout << "Settings file not found, using defaults" << std::endl;
+            settings = json::object(); // Create an empty JSON object
         }
-    } else {
-        std::cout << "Settings file not found, using defaults" << std::endl;
-        settings = json::object(); // Create an empty JSON object
+        if (!settings.contains("font")) {
+            settings["font"] = "default";
+        }
+        // Set default values if not present
+        if (!settings.contains("backgroundColor")) {
+            settings["backgroundColor"] = {0.45f, 0.55f, 0.60f, 1.00f};
+        }
+        if (!settings.contains("fontSize")) {
+            settings["fontSize"] = 16.0f;
+        }
+        if (!settings.contains("splitPos")) {
+            settings["splitPos"] = 0.3f;
+        }
+        if (!settings.contains("theme")) {
+            settings["theme"] = "default";
+        }
+        if (!settings.contains("themes")) {
+        settings["themes"] = {
+            {"default", {
+                {"text", {1.0f, 1.0f, 1.0f, 1.0f}},
+                {"background", {0.2f, 0.2f, 0.2f, 1.0f}},
+                {"keyword", {0.0f, 0.4f, 1.0f, 1.0f}},
+                {"string", {0.87f, 0.87f, 0.0f, 1.0f}},
+                {"number", {0.0f, 0.8f, 0.8f, 1.0f}},
+                {"comment", {0.5f, 0.5f, 0.5f, 1.0f}},
+                {"heading", {0.9f, 0.5f, 0.2f, 1.0f}},
+                {"bold", {1.0f, 0.7f, 0.7f, 1.0f}},
+                {"italic", {0.7f, 1.0f, 0.7f, 1.0f}},
+                {"link", {0.4f, 0.4f, 1.0f, 1.0f}},
+                {"code_block", {0.8f, 0.8f, 0.8f, 1.0f}},
+                {"inline_code", {0.7f, 0.7f, 0.7f, 1.0f}},
+                {"tag", {0.3f, 0.7f, 0.9f, 1.0f}},
+                {"attribute", {0.9f, 0.7f, 0.3f, 1.0f}},
+                {"selector", {0.9f, 0.4f, 0.6f, 1.0f}},
+                {"property", {0.6f, 0.9f, 0.4f, 1.0f}},
+                {"value", {0.4f, 0.6f, 0.9f, 1.0f}},
+                {"key", {0.9f, 0.6f, 0.4f, 1.0f}}
+            }}
+        };
     }
-     if (!settings.contains("font")) {
-        settings["font"] = "default";
-    }
-    // Set default values if not present
-    if (!settings.contains("backgroundColor")) {
-        settings["backgroundColor"] = {0.45f, 0.55f, 0.60f, 1.00f};
-    }
-    if (!settings.contains("fontSize")) {
-        settings["fontSize"] = 16.0f;
-    }
-    if (!settings.contains("splitPos")) {
-        settings["splitPos"] = 0.3f;
-    }
-    if (!settings.contains("theme")) {
-        settings["theme"] = "default";
-    }
-    if (!settings.contains("themes")) {
-    settings["themes"] = {
-        {"default", {
-            {"text", {1.0f, 1.0f, 1.0f, 1.0f}},
-            {"background", {0.2f, 0.2f, 0.2f, 1.0f}},
-            {"keyword", {0.0f, 0.4f, 1.0f, 1.0f}},
-            {"string", {0.87f, 0.87f, 0.0f, 1.0f}},
-            {"number", {0.0f, 0.8f, 0.8f, 1.0f}},
-            {"comment", {0.5f, 0.5f, 0.5f, 1.0f}},
-            {"heading", {0.9f, 0.5f, 0.2f, 1.0f}},
-            {"bold", {1.0f, 0.7f, 0.7f, 1.0f}},
-            {"italic", {0.7f, 1.0f, 0.7f, 1.0f}},
-            {"link", {0.4f, 0.4f, 1.0f, 1.0f}},
-            {"code_block", {0.8f, 0.8f, 0.8f, 1.0f}},
-            {"inline_code", {0.7f, 0.7f, 0.7f, 1.0f}},
-            {"tag", {0.3f, 0.7f, 0.9f, 1.0f}},
-            {"attribute", {0.9f, 0.7f, 0.3f, 1.0f}},
-            {"selector", {0.9f, 0.4f, 0.6f, 1.0f}},
-            {"property", {0.6f, 0.9f, 0.4f, 1.0f}},
-            {"value", {0.4f, 0.6f, 0.9f, 1.0f}},
-            {"key", {0.9f, 0.6f, 0.4f, 1.0f}}
-        }}
-    };
-}
-    
-    splitPos = settings["splitPos"].get<float>();
-    // Only update lastSettingsModification if the file exists
-    if (fs::exists(settingsPath)) {
-        lastSettingsModification = fs::last_write_time(settingsPath);
-    } else {
-        lastSettingsModification = fs::file_time_type::min();
-    }
-
-    std::cout << "Current settings: " << settings.dump(4) << std::endl;
-}
-
-void Settings::saveSettings() {
-    std::ofstream settingsFile(settingsPath);
-    if (settingsFile.is_open()) {
-        settingsFile << std::setw(4) << settings << std::endl;
-    }
-}
-void Settings::checkSettingsFile() {
-    if (!fs::exists(settingsPath)) {
-        std::cout << "Settings file does not exist, skipping check" << std::endl;
-        return;
-    }
-
-    auto currentModification = fs::last_write_time(settingsPath);
-      
-    if (currentModification > lastSettingsModification) {
-        std::cout << "Settings file has been modified, reloading" << std::endl;
-        json oldSettings = settings;
-        loadSettings();
-        lastSettingsModification = currentModification;
         
-        // Check if relevant settings have changed
-        if (oldSettings["backgroundColor"] != settings["backgroundColor"] ||
-            oldSettings["fontSize"] != settings["fontSize"] ||
-            oldSettings["splitPos"] != settings["splitPos"] ||
-            oldSettings["theme"] != settings["theme"] ||
-            oldSettings["themes"] != settings["themes"] ||
-            oldSettings["font"] != settings["font"]) {
-            settingsChanged = true;
-            
-            // Check if theme or themes have changed
-            if (oldSettings["theme"] != settings["theme"] || oldSettings["themes"] != settings["themes"]) {
-                themeChanged = true;
-            }
+        splitPos = settings["splitPos"].get<float>();
+        // Only update lastSettingsModification if the file exists
+        if (fs::exists(settingsPath)) {
+            lastSettingsModification = fs::last_write_time(settingsPath);
+        } else {
+            lastSettingsModification = fs::file_time_type::min();
+        }
 
-            // Check if font has changed
-            if (oldSettings["font"] != settings["font"]) {
-                fontChanged = true;
+        std::cout << "Current settings: " << settings.dump(4) << std::endl;
+    }
+
+    void Settings::saveSettings() {
+        std::ofstream settingsFile(settingsPath);
+        if (settingsFile.is_open()) {
+            settingsFile << std::setw(4) << settings << std::endl;
+        }
+    }
+    void Settings::checkSettingsFile() {
+        if (!fs::exists(settingsPath)) {
+            std::cout << "Settings file does not exist, skipping check" << std::endl;
+            return;
+        }
+
+        auto currentModification = fs::last_write_time(settingsPath);
+        
+        if (currentModification > lastSettingsModification) {
+            std::cout << "Settings file has been modified, reloading" << std::endl;
+            json oldSettings = settings;
+            loadSettings();
+            lastSettingsModification = currentModification;
+            
+            // Check if relevant settings have changed
+            if (oldSettings["backgroundColor"] != settings["backgroundColor"] ||
+                oldSettings["fontSize"] != settings["fontSize"] ||
+                oldSettings["splitPos"] != settings["splitPos"] ||
+                oldSettings["theme"] != settings["theme"] ||
+                oldSettings["themes"] != settings["themes"] ||
+                oldSettings["font"] != settings["font"]) {
+                settingsChanged = true;
+                
+                // Check if theme or themes have changed
+                if (oldSettings["theme"] != settings["theme"] || oldSettings["themes"] != settings["themes"]) {
+                    themeChanged = true;
+                }
+
+                // Check if font has changed
+                if (oldSettings["font"] != settings["font"]) {
+                    fontChanged = true;
+                }
             }
         }
     }
-}
 
 
 


### PR DESCRIPTION
![Bookmarks](https://i.imgur.com/qommnIO.png)


updated bookmarks keybindings to resolve conflict with mac os cmd shift 3/4 screenshot.  now both cmd/ctrl shift and cmd/ctrl alt can be used to set bookmarks.   also cmd b open a list of current bookmarks and displays them neatly, cmd b to close this window aswell.